### PR TITLE
Update deprecated createSocket usage in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -93,6 +93,7 @@ Here is how you might implement a server that prints the messages it receives
 and responds to them with "Hello, world!":
 
 ```java
+import org.zeromq.SocketType;
 import org.zeromq.ZMQ;
 import org.zeromq.ZContext;
 
@@ -102,7 +103,7 @@ public class hwserver
     {
         try (ZContext context = new ZContext()) {
             // Socket to talk to clients
-            ZMQ.Socket socket = context.createSocket(ZMQ.REP);
+            ZMQ.Socket socket = context.createSocket(SocketType.REP);
             socket.bind("tcp://*:5555");
 
             while (!Thread.currentThread().isInterrupted()) {


### PR DESCRIPTION
The README example code uses a deprecated call to `createSocket(int)`. 
![image](https://user-images.githubusercontent.com/21371686/94716219-86c5a700-031c-11eb-8833-52d1fbc95e06.png)

Swapping the `int` parameter for a `SocketType` resolves the deprecation warning.